### PR TITLE
Revert "Encode str in UnresolvedCustomeType in order to handle unicode names."

### DIFF
--- a/src/zeep/xsd/types/unresolved.py
+++ b/src/zeep/xsd/types/unresolved.py
@@ -27,7 +27,7 @@ class UnresolvedCustomType(Type):
     def __init__(self, qname, base_type, schema):
         assert qname is not None
         self.qname = qname
-        self.name = qname.localname.encode('utf-8')
+        self.name = str(qname.localname)
         self.schema = schema
         self.base_type = base_type
 


### PR DESCRIPTION


This reverts commit 774cca1fcadf36dfb14c3591b583bf7c22e98dc4.